### PR TITLE
chore(types): removed caseSensitive from CompareOptions

### DIFF
--- a/flow-typed/natural-orderby.js
+++ b/flow-typed/natural-orderby.js
@@ -1,7 +1,5 @@
 type $npm$naturalOrderBy$CompareFn = (valueA: mixed, valueB: mixed) => number;
 
-type $npm$naturalOrderBy$CaseSensitive = boolean;
-
 type $npm$naturalOrderBy$OrderEnum = 'asc' | 'desc';
 
 type $npm$naturalOrderBy$Order =
@@ -9,7 +7,6 @@ type $npm$naturalOrderBy$Order =
   | $npm$naturalOrderBy$CompareFn;
 
 type $npm$naturalOrderBy$CompareOptions = {|
-  $npm$naturalOrderBy$CaseSensitive?: $npm$naturalOrderBy$CaseSensitive,
   order?: $npm$naturalOrderBy$OrderEnum,
 |};
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -2,9 +2,6 @@ export type Identifier<T> = number | string | ((value: T) => unknown);
 export type Order<T> = 'asc' | 'desc' | ((valueA: T, valueB: T) => number);
 export function orderBy<T>(collection: T[], identifiers?: Array<Identifier<T>> | Identifier<T>, orders?: Array<Order<T>> | Order<T>): T[];
 
-export interface CompareOptions {
-  caseSensitive?: boolean,
-  order?: 'asc' | 'desc'
-}
+export interface CompareOptions { order?: 'asc' | 'desc' }
 export type CompareFn = ((valueA: unknown, valueB: unknown) => number);
 export function compare(options?: CompareOptions): CompareFn;


### PR DESCRIPTION
The `caseSensitive` option was removed in #35, but not from the type definitions.