### PR TITLE
Update `Identifier<T>` to be `keyof T` instead of any `string`

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -17,7 +17,7 @@ export type BaseCompareOptions = {
 
 export type IdentifierFn<T> = (value: T) => unknown;
 
-export type Identifier<T> = IdentifierFn<T> | string | number;
+export type Identifier<T> = IdentifierFn<T> | keyof T | number;
 
 export type ParsedNumber = number;
 


### PR DESCRIPTION
This provides stronger type checking when using an accessor identifier. I recently refactored a property's name in one of my project's types but forgot to change this property when ordering. This narrower type would have caught the issue.

Before:

<img width="425" alt="image" src="https://github.com/user-attachments/assets/8c22dcce-8908-45d5-908c-54fded0b22fc">

After:

<img width="967" alt="image" src="https://github.com/user-attachments/assets/a678813d-9938-4fdb-980f-8d0050fcf2bf">

As a side effect, it also provide some nice IntelliSense:

<img width="437" alt="image" src="https://github.com/user-attachments/assets/28650df9-bd67-42c4-9dab-421eeb7d9a66">
