### PR TITLE
fix: use host locale setting instead of static 'en' locale as default

### DIFF
--- a/README.md
+++ b/README.md
@@ -342,17 +342,17 @@ Creates a compare function that defines the natural sort order and which may be 
 compare(options?: CompareOptions): CompareFn
 ```
 
-| Type             | Value                                                        |
-| :--------------- | :----------------------------------------------------------- |
-| `CompareOptions` | <code>{ order?: 'asc' &#124; 'desc', locale: string }</code> |
-| `CompareFn`      | <code>(valueA: unknown, valueB: unknown) => number</code>    |
+| Type             | Value                                                         |
+| :--------------- | :------------------------------------------------------------ |
+| `CompareOptions` | <code>{ order?: 'asc' &#124; 'desc', locale?: string }</code> |
+| `CompareFn`      | <code>(valueA: unknown, valueB: unknown) => number</code>     |
 
 #### Description
 
 `compare()` returns a compare function that defines the natural sort order and which may be passed to [`Array.prototype.sort()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
 
 If `options` or its property `order` is unspecified, values are sorted in ascending sort order. Otherwise, specify an order of `'desc'` for descending or `'asc'` for ascending sort order of values.
-If unicode strings should be ordered corresponding to a specific locale setting, specify the according value for the options property `locale`. It must be a string with a BCP 47 language tag.
+If unicode strings should be ordered corresponding to a specific locale setting, specify the according value for the options property `locale`. It must be a string with a BCP 47 language tag. If the argument is unspecified, the host locale setting will be used.
 
 #### Examples
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -342,17 +342,17 @@ Creates a compare function that defines the natural sort order and which may be 
 compare(options?: CompareOptions): CompareFn
 ```
 
-| Type             | Value                                                        |
-| :--------------- | :----------------------------------------------------------- |
-| `CompareOptions` | <code>{ order?: 'asc' &#124; 'desc', locale: string }</code> |
-| `CompareFn`      | <code>(valueA: unknown, valueB: unknown) => number</code>    |
+| Type             | Value                                                         |
+| :--------------- | :------------------------------------------------------------ |
+| `CompareOptions` | <code>{ order?: 'asc' &#124; 'desc', locale?: string }</code> |
+| `CompareFn`      | <code>(valueA: unknown, valueB: unknown) => number</code>     |
 
 #### Description
 
 `compare()` returns a compare function that defines the natural sort order and which may be passed to [`Array.prototype.sort()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort).
 
 If `options` or its property `order` is unspecified, values are sorted in ascending sort order. Otherwise, specify an order of `'desc'` for descending or `'asc'` for ascending sort order of values.
-If unicode strings should be ordered corresponding to a specific locale setting, specify the according value for the options property `locale`. It must be a string with a BCP 47 language tag.
+If unicode strings should be ordered corresponding to a specific locale setting, specify the according value for the options property `locale`. It must be a string with a BCP 47 language tag. If the option is unspecified, the host locale setting will be used.
 
 #### Examples
 

--- a/src/compare/__tests__/index.test.ts
+++ b/src/compare/__tests__/index.test.ts
@@ -4,7 +4,7 @@ import { compare } from '../index';
 
 const defaultOptions: CompareOptions = {
   order: 'asc',
-  locale: 'en',
+  locale: undefined,
 };
 
 jest.mock('../../utils/baseCompare', () => ({

--- a/src/orderBy/__tests__/index.test.ts
+++ b/src/orderBy/__tests__/index.test.ts
@@ -16,11 +16,10 @@ describe('orderBy()', () => {
     const collection = ['Fred', 'barney', 'frank', 'Bob'];
     const identifiers = undefined;
     const orders = undefined;
-    const locale = undefined;
 
-    orderBy(collection, identifiers, orders, locale);
+    orderBy(collection, identifiers, orders);
     expect(baseOrderBy).toHaveBeenCalledTimes(1);
-    expect(baseOrderBy).toHaveBeenCalledWith(collection, [], [], 'en');
+    expect(baseOrderBy).toHaveBeenCalledWith(collection, [], [], undefined);
   });
   it('should call baseOrderBy() with provided collection, identifiers, orders and locale arguments', () => {
     const collection = ['Fred', 'barney', 'frank', 'Bob'];

--- a/src/orderBy/index.ts
+++ b/src/orderBy/index.ts
@@ -13,7 +13,7 @@ export function orderBy<T>(
   collection: ReadonlyArray<T>,
   identifiers?: ReadonlyArray<Identifier<T>> | Identifier<T> | null,
   orders?: ReadonlyArray<Order> | Order | null,
-  locale: Locale = 'en',
+  locale?: Locale,
 ): Array<T> {
   if (!collection || !Array.isArray(collection)) {
     return [];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -14,7 +14,7 @@ export type CompareOptions =
 
 export type BaseCompareOptions = {
   order: Order;
-  locale: Locale;
+  locale?: Locale;
 };
 
 export type Locale = string;

--- a/src/utils/__tests__/baseCompare.test.ts
+++ b/src/utils/__tests__/baseCompare.test.ts
@@ -5,16 +5,12 @@ describe('baseCompare()', () => {
     it('should order elements ascending and case insensitive', () => {
       const origArray = ['Fred', 'barney', 'frank', 'Bob'];
       const sortArray = ['barney', 'Bob', 'frank', 'Fred'];
-      expect(
-        origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-      ).toEqual(sortArray);
+      expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(sortArray);
     });
     it('should order elements descending and case insensitive', () => {
       const origArray = ['Fred', 'barney', 'frank', 'Bob'];
       const sortArray = ['Fred', 'frank', 'Bob', 'barney'];
-      expect(
-        origArray.sort(baseCompare({ order: 'desc', locale: 'en' })),
-      ).toEqual(sortArray);
+      expect(origArray.sort(baseCompare({ order: 'desc' }))).toEqual(sortArray);
     });
   });
 
@@ -23,36 +19,36 @@ describe('baseCompare()', () => {
       const origArray = ['a', 1];
       const sortArray = [1, 'a'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('number vs numeric string - should remain unchanged', () => {
       const origArray = ['1', 1];
       const sortArray = ['1', 1];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('float vs float strings', () => {
       const origArray = [0.3, '.2', '.5', 0.1];
       const sortArray = [0.1, '.2', 0.3, '.5'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('padding numeric string vs number', () => {
       const origArray = ['02', 3, 2, '01'];
       const sortArray = ['01', '02', 2, 3];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -146,9 +142,9 @@ describe('baseCompare()', () => {
         'U17',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('redundant alphanumerics', () => {
@@ -173,27 +169,27 @@ describe('baseCompare()', () => {
         'Newsstand stop, Position: 4',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('sort alphanumerics case insensitive', () => {
       const origArray = ['9', 'bbbb', 'aa', 'AA', 'Aa', 'aA', 'BB', 'bB'];
       const sortArray = ['9', 'aa', 'AA', 'Aa', 'aA', 'BB', 'bB', 'bbbb'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('numerics with leading zeros and prefixed by a character', () => {
       const origArray = ['A110', 'A100', 'A090', 'A200', 'A50'];
       const sortArray = ['A50', 'A090', 'A100', 'A110', 'A200'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('number first', () => {
@@ -228,9 +224,9 @@ describe('baseCompare()', () => {
         '33K',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('alphanumeric strings containing whitespace', () => {
@@ -251,18 +247,18 @@ describe('baseCompare()', () => {
         'imgz199',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('numbers with separators', () => {
       const origArray = ['100', '20', '10_000', '5_000', '2_000_000'];
       const sortArray = ['20', '100', '5_000', '10_000', '2_000_000'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('alphanumerics containing very large numbers', () => {
@@ -279,45 +275,45 @@ describe('baseCompare()', () => {
         'MySnmp 4234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('alphanumerics containing "." and "-"', () => {
       const origArray = ['bar.1-2', 'bar.1'];
       const sortArray = ['bar.1', 'bar.1-2'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('character string vs alphanumeric string', () => {
       const origArray = ['SomeString', 'SomeString 1'];
       const sortArray = ['SomeString', 'SomeString 1'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('numerics with unit', () => {
       const origArray = ['2.2 sec', '1.9 sec', '1.53 sec'];
       const sortArray = ['1.53 sec', '1.9 sec', '2.2 sec'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('numerics with unit without whitespace', () => {
       const origArray = ['2.2sec', '1.9sec', '1.53sec'];
       const sortArray = ['1.53sec', '1.9sec', '2.2sec'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -337,9 +333,9 @@ describe('baseCompare()', () => {
         '10/12/2008',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('more similar dates', () => {
@@ -356,9 +352,9 @@ describe('baseCompare()', () => {
         '01/10/2008',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('JavaScript toString(), different timezones', () => {
@@ -373,9 +369,9 @@ describe('baseCompare()', () => {
         'Wed Jan 01 2010 00:00:00 GMT-0800 (Pacific Standard Time)',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('Date.toString(), Date.toLocaleString()', () => {
@@ -390,9 +386,9 @@ describe('baseCompare()', () => {
         'Monday, August 2, 2010',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('Date.toUTCString()', () => {
@@ -407,9 +403,9 @@ describe('baseCompare()', () => {
         'Mon, 3 May 2010 17:45:30 GMT',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('custom date formats', () => {
@@ -426,9 +422,9 @@ describe('baseCompare()', () => {
         'Monday, August 2, 2010 1:45 PM',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('more custom date formats', () => {
@@ -445,9 +441,9 @@ describe('baseCompare()', () => {
         'Monday, August 2, 2010 1:45:01 PM',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('even more custom date formats', () => {
@@ -462,9 +458,9 @@ describe('baseCompare()', () => {
         '2/15/2009 1:45 PM',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('ISO8601 Dates', () => {
@@ -481,9 +477,9 @@ describe('baseCompare()', () => {
         '2010-06-15T13:45:30',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('ISO8601-ish YYYY-MM-DD hh:mm:ss - which does not parse into a Date instance', () => {
@@ -498,9 +494,9 @@ describe('baseCompare()', () => {
         '2010-06-15 13:45:30',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('RFC1123 testing different timezones', () => {
@@ -515,18 +511,18 @@ describe('baseCompare()', () => {
         'Mon, 15 Jun 2009 20:45:30 PDT',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('unix epoch, Date.getTime()', () => {
       const origArray = ['1245098730000', '14330728000', '1245098728000'];
       const sortArray = ['14330728000', '1245098728000', '1245098730000'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('mixed Date types', () => {
@@ -543,9 +539,9 @@ describe('baseCompare()', () => {
         '2015-01-01',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -555,18 +551,18 @@ describe('baseCompare()', () => {
       const origArray = ['1.0.2', '1.0.1', '1.0.0', '1.0.9'];
       const sortArray = ['1.0.0', '1.0.1', '1.0.2', '1.0.9'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('more version numbers', () => {
       const origArray = ['1.1.100', '1.1.1', '1.1.10', '1.1.54'];
       const sortArray = ['1.1.1', '1.1.10', '1.1.54', '1.1.100'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('even more version numbers', () => {
@@ -587,18 +583,18 @@ describe('baseCompare()', () => {
         '2.0.1',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('multi-digit branch release', () => {
       const origArray = ['1.0.03', '1.0.003', '1.0.002', '1.0.0001'];
       const sortArray = ['1.0.0001', '1.0.002', '1.0.003', '1.0.03'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('more close version numbers', () => {
@@ -621,9 +617,9 @@ describe('baseCompare()', () => {
         '2.1.2',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('string first', () => {
@@ -642,18 +638,18 @@ describe('baseCompare()', () => {
         'myrelease-1.2.3',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('version numbers containing float-like numbers', () => {
       const origArray = ['v1.100', 'v1.1', 'v1.10', 'v1.54'];
       const sortArray = ['v1.1', 'v1.10', 'v1.54', 'v1.100'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -663,63 +659,63 @@ describe('baseCompare()', () => {
       const origArray = ['10', 9, 2, '1', '4'];
       const sortArray = ['1', 2, '4', 9, '10'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('0 left-padded numbers', () => {
       const origArray = ['0001', '002', '001'];
       const sortArray = ['0001', '001', '002'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('0 left-padded numbers and regular numbers', () => {
       const origArray = [2, 1, '1', '0001', '002', '02', '001'];
       const sortArray = [1, '1', '0001', '001', 2, '002', '02'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('decimal string vs decimal, different precision', () => {
       const origArray = ['10.0401', 10.022, 10.042, '10.021999'];
       const sortArray = ['10.021999', 10.022, '10.0401', 10.042];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('decimal string vs decimal, same precision', () => {
       const origArray = ['10.04', 10.02, 10.03, '10.01'];
       const sortArray = ['10.01', 10.02, 10.03, '10.04'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('float/decimal with "F" or "D" notation', () => {
       const origArray = ['10.04f', '10.039F', '10.038d', '10.037D'];
       const sortArray = ['10.037D', '10.038d', '10.039F', '10.04f'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('not foat/decimal notation', () => {
       const origArray = ['10.004Z', '10.039T', '10.038ooo', '10.037g'];
       const sortArray = ['10.004Z', '10.037g', '10.038ooo', '10.039T'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('scientific notation', () => {
@@ -738,27 +734,27 @@ describe('baseCompare()', () => {
         '1.52e15',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('negative numbers as strings', () => {
       const origArray = ['-1', '-2', '4', '-3', '0', '-5'];
       const sortArray = ['-5', '-3', '-2', '-1', '0', '4'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('numerics with prepended zero', () => {
       const origArray = ['1', '02', '3'];
       const sortArray = ['1', '02', '3'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('numerics with prepended zero and optional trailing characters', () => {
@@ -785,27 +781,27 @@ describe('baseCompare()', () => {
         '13',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('negative numbers as strings - mixed input type, string + numeric', () => {
       const origArray = [-1, '-2', 4, -3, '0', '-5'];
       const sortArray = ['-5', -3, '-2', -1, '0', 4];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('negative floats - all numeric', () => {
       const origArray = [-2.01, -2.1, 4.144, 4.1, -2.001, -5];
       const sortArray = [-5, -2.1, -2.01, -2.001, 4.1, 4.144];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -814,9 +810,7 @@ describe('baseCompare()', () => {
     const origArray = ['1c', '1b', '1a', '1f', '1d', '2b', '2a', '2c', '1e'];
     const sortArray = ['1a', '1b', '1c', '1d', '1e', '1f', '2a', '2b', '2c'];
     it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-      expect(
-        origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-      ).toEqual(sortArray);
+      expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(sortArray);
     });
   });
 
@@ -840,9 +834,7 @@ describe('baseCompare()', () => {
       '192.168.1.1',
     ];
     it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-      expect(
-        origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-      ).toEqual(sortArray);
+      expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(sortArray);
     });
   });
 
@@ -851,9 +843,9 @@ describe('baseCompare()', () => {
       const origArray = ['img12.png', 'img10.png', 'img2.png', 'img1.png'];
       const sortArray = ['img1.png', 'img2.png', 'img10.png', 'img12.png'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('complex filenames', () => {
@@ -878,9 +870,9 @@ describe('baseCompare()', () => {
         'asset_47103.jpg',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('unix filenames', () => {
@@ -895,9 +887,9 @@ describe('baseCompare()', () => {
         './system/kernel/js/02_my.desktop.js',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -906,9 +898,7 @@ describe('baseCompare()', () => {
     const origArray = ['alpha', ' 1', '  3', ' 2', 0];
     const sortArray = [0, ' 1', ' 2', '  3', 'alpha'];
     it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-      expect(
-        origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-      ).toEqual(sortArray);
+      expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(sortArray);
     });
   });
 
@@ -917,18 +907,18 @@ describe('baseCompare()', () => {
       const origArray = ['10023', '999', '', 2, 5.663, 5.6629];
       const sortArray = ['', 2, 5.6629, 5.663, '999', '10023'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('zero as digits and strings and empty strings', () => {
       const origArray = [1, 0, '0', ''];
       const sortArray = ['', 0, '0', 1];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -938,18 +928,18 @@ describe('baseCompare()', () => {
       const origArray = ['0xA', '0x9', '0x99'];
       const sortArray = ['0x9', '0xA', '0x99'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('fake hex numbers', () => {
       const origArray = ['0xZZ', '0xVVV', '0xVEV', '0xUU'];
       const sortArray = ['0xUU', '0xVEV', '0xVVV', '0xZZ'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -959,9 +949,9 @@ describe('baseCompare()', () => {
       const origArray = ['\u0044', '\u0055', '\u0054', '\u0043'];
       const sortArray = ['\u0043', '\u0044', '\u0054', '\u0055'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('latin-1 supplement, default locale', () => {
@@ -986,9 +976,9 @@ describe('baseCompare()', () => {
         '\u007a',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('Sorting umlauts characters \xC4, \xD6, \xDC', () => {
@@ -1011,27 +1001,27 @@ describe('baseCompare()', () => {
         '\xDCxk\xFCll',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('localeCompare and equal chunks', () => {
       const origArray = ['drüben', 'hüben', 'wie', 'drüben', 'hüben'];
       const sortArray = ['drüben', 'drüben', 'hüben', 'hüben', 'wie'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('diacritics', () => {
       const origArray = ['b', 'd', 'f', 'A', 'Cé', 'E'];
       const sortArray = ['A', 'b', 'Cé', 'd', 'E', 'f'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('considers locale option', () => {
@@ -1073,18 +1063,18 @@ describe('baseCompare()', () => {
         undefined,
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('alphanumeric sparse array', () => {
       const origArray = [2, 10, 1, 'azd', undefined, 'asd'];
       const sortArray = [1, 2, 10, 'asd', 'azd', undefined];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -1094,18 +1084,18 @@ describe('baseCompare()', () => {
       const origArray = ['A', 'b', 'C', 'd', 'E', 'f'];
       const sortArray = ['A', 'b', 'C', 'd', 'E', 'f'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('case insensitive un-sorted array', () => {
       const origArray = ['A', 'C', 'E', 'b', 'd', 'f'];
       const sortArray = ['A', 'b', 'C', 'd', 'E', 'f'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });
@@ -1125,9 +1115,9 @@ describe('baseCompare()', () => {
         'ignore leading spaces: 2-2',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('Ignoring multiple adjacent spaces (m.a.s)', () => {
@@ -1144,9 +1134,9 @@ describe('baseCompare()', () => {
         'ignore m.a.s spaces: 2-2',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('Equivalent whitespace characters', () => {
@@ -1167,9 +1157,9 @@ describe('baseCompare()', () => {
         'Equiv. spaces: 3-3',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('Case Indepenent sort', () => {
@@ -1186,9 +1176,9 @@ describe('baseCompare()', () => {
         'cASE INDEPENENT: 3-2',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('Numeric fields as numerics', () => {
@@ -1205,9 +1195,9 @@ describe('baseCompare()', () => {
         'foo1000bar99baz10.txt',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('Title sorts', () => {
@@ -1224,9 +1214,9 @@ describe('baseCompare()', () => {
         'Wanda',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
     describe('Equivalent accented characters (and case) case insensitive)', () => {
@@ -1243,9 +1233,9 @@ describe('baseCompare()', () => {
         'Equiv. \xfd accents: 2-2',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(
-          origArray.sort(baseCompare({ order: 'asc', locale: 'en' })),
-        ).toEqual(sortArray);
+        expect(origArray.sort(baseCompare({ order: 'asc' }))).toEqual(
+          sortArray,
+        );
       });
     });
   });

--- a/src/utils/__tests__/baseOrderBy.test.ts
+++ b/src/utils/__tests__/baseOrderBy.test.ts
@@ -7,12 +7,12 @@ describe('baseOrderBy()', () => {
       it('should order elements ascending and case insensitive', () => {
         const origArray = ['Fred', 'barney', 'frank', 'Bob'];
         const sortArray = ['barney', 'Bob', 'frank', 'Fred'];
-        expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+        expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
       });
       it('should order elements descending and case insensitive', () => {
         const origArray = ['Fred', 'barney', 'frank', 'Bob'];
         const sortArray = ['Fred', 'frank', 'Bob', 'barney'];
-        expect(baseOrderBy(origArray, [], ['desc'], 'en')).toEqual(sortArray);
+        expect(baseOrderBy(origArray, [], ['desc'])).toEqual(sortArray);
       });
     });
 
@@ -21,28 +21,28 @@ describe('baseOrderBy()', () => {
         const origArray = ['a', 1];
         const sortArray = [1, 'a'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('number vs numeric string - should remain unchanged', () => {
         const origArray = ['1', 1];
         const sortArray = ['1', 1];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('float vs float strings', () => {
         const origArray = [0.3, '.2', '.5', 0.1];
         const sortArray = [0.1, '.2', 0.3, '.5'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('padding numeric string vs number', () => {
         const origArray = ['02', 3, 2, '01'];
         const sortArray = ['01', '02', 2, 3];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -106,7 +106,7 @@ describe('baseOrderBy()', () => {
         undefined,
       ];
       it('should sort all available data types properly', () => {
-        expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+        expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
       });
     });
 
@@ -199,7 +199,7 @@ describe('baseOrderBy()', () => {
           'U17',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('redundant alphanumerics', () => {
@@ -224,7 +224,7 @@ describe('baseOrderBy()', () => {
           'Newsstand stop, Position: 4',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('sort alphanumerics case insensitive', () => {
@@ -269,14 +269,14 @@ describe('baseOrderBy()', () => {
           'bbbb',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('numerics with leading zeros and prefixed by a character', () => {
         const origArray = ['A110', 'A100', 'A090', 'A200', 'A50'];
         const sortArray = ['A50', 'A090', 'A100', 'A110', 'A200'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('number first', () => {
@@ -311,7 +311,7 @@ describe('baseOrderBy()', () => {
           '33K',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('alphanumeric strings containing whitespace', () => {
@@ -332,7 +332,7 @@ describe('baseOrderBy()', () => {
           'imgz199',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('alphanumerics containing very large numbers', () => {
@@ -349,35 +349,35 @@ describe('baseOrderBy()', () => {
           'MySnmp 4234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567891234567',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('alphanumerics containing "." and "-"', () => {
         const origArray = ['bar.1-2', 'bar.1'];
         const sortArray = ['bar.1', 'bar.1-2'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('character string vs alphanumeric string', () => {
         const origArray = ['SomeString', 'SomeString 1'];
         const sortArray = ['SomeString', 'SomeString 1'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('numerics with unit', () => {
         const origArray = ['2.2 sec', '1.9 sec', '1.53 sec'];
         const sortArray = ['1.53 sec', '1.9 sec', '2.2 sec'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('numerics with unit without whitespace', () => {
         const origArray = ['2.2sec', '1.9sec', '1.53sec'];
         const sortArray = ['1.53sec', '1.9sec', '2.2sec'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -397,7 +397,7 @@ describe('baseOrderBy()', () => {
           '10/12/2008',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('more similar dates', () => {
@@ -414,7 +414,7 @@ describe('baseOrderBy()', () => {
           '01/10/2008',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('JavaScript toString(), different timezones', () => {
@@ -429,7 +429,7 @@ describe('baseOrderBy()', () => {
           'Wed Jan 01 2010 00:00:00 GMT-0800 (Pacific Standard Time)',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('Date.toString(), Date.toLocaleString()', () => {
@@ -444,7 +444,7 @@ describe('baseOrderBy()', () => {
           'Monday, August 2, 2010',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('Date.toUTCString()', () => {
@@ -459,7 +459,7 @@ describe('baseOrderBy()', () => {
           'Mon, 3 May 2010 17:45:30 GMT',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('custom date formats', () => {
@@ -476,7 +476,7 @@ describe('baseOrderBy()', () => {
           'Monday, August 2, 2010 1:45 PM',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('more custom date formats', () => {
@@ -493,7 +493,7 @@ describe('baseOrderBy()', () => {
           'Monday, August 2, 2010 1:45:01 PM',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('even more custom date formats', () => {
@@ -508,7 +508,7 @@ describe('baseOrderBy()', () => {
           '2/15/2009 1:45 PM',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('ISO8601 Dates', () => {
@@ -525,7 +525,7 @@ describe('baseOrderBy()', () => {
           '2010-06-15T13:45:30',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('ISO8601-ish YYYY-MM-DD hh:mm:ss - which does not parse into a Date instance', () => {
@@ -540,7 +540,7 @@ describe('baseOrderBy()', () => {
           '2010-06-15 13:45:30',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('RFC1123 testing different timezones', () => {
@@ -555,14 +555,14 @@ describe('baseOrderBy()', () => {
           'Mon, 15 Jun 2009 20:45:30 PDT',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('unix epoch, Date.getTime()', () => {
         const origArray = ['1245098730000', '14330728000', '1245098728000'];
         const sortArray = ['14330728000', '1245098728000', '1245098730000'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('mixed Date types', () => {
@@ -579,7 +579,7 @@ describe('baseOrderBy()', () => {
           '2015-01-01',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -589,14 +589,14 @@ describe('baseOrderBy()', () => {
         const origArray = ['1.0.2', '1.0.1', '1.0.0', '1.0.9'];
         const sortArray = ['1.0.0', '1.0.1', '1.0.2', '1.0.9'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('more version numbers', () => {
         const origArray = ['1.1.100', '1.1.1', '1.1.10', '1.1.54'];
         const sortArray = ['1.1.1', '1.1.10', '1.1.54', '1.1.100'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('even more version numbers', () => {
@@ -617,14 +617,14 @@ describe('baseOrderBy()', () => {
           '2.0.1',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('multi-digit branch release', () => {
         const origArray = ['1.0.03', '1.0.003', '1.0.002', '1.0.0001'];
         const sortArray = ['1.0.0001', '1.0.002', '1.0.003', '1.0.03'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('more close version numbers', () => {
@@ -647,7 +647,7 @@ describe('baseOrderBy()', () => {
           '2.1.2',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('string first', () => {
@@ -666,14 +666,14 @@ describe('baseOrderBy()', () => {
           'myrelease-1.2.3',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('version numbers containing float-like numbers', () => {
         const origArray = ['v1.100', 'v1.1', 'v1.10', 'v1.54'];
         const sortArray = ['v1.1', 'v1.10', 'v1.54', 'v1.100'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -683,49 +683,49 @@ describe('baseOrderBy()', () => {
         const origArray = ['10', 9, 2, '1', '4'];
         const sortArray = ['1', 2, '4', 9, '10'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('0 left-padded numbers', () => {
         const origArray = ['0001', '002', '001'];
         const sortArray = ['0001', '001', '002'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('0 left-padded numbers and regular numbers', () => {
         const origArray = [2, 1, '1', '0001', '002', '02', '001'];
         const sortArray = [1, '1', '0001', '001', 2, '002', '02'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('decimal string vs decimal, different precision', () => {
         const origArray = ['10.0401', 10.022, 10.042, '10.021999'];
         const sortArray = ['10.021999', 10.022, '10.0401', 10.042];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('decimal string vs decimal, same precision', () => {
         const origArray = ['10.04', 10.02, 10.03, '10.01'];
         const sortArray = ['10.01', 10.02, 10.03, '10.04'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('float/decimal with "F" or "D" notation', () => {
         const origArray = ['10.04f', '10.039F', '10.038d', '10.037D'];
         const sortArray = ['10.037D', '10.038d', '10.039F', '10.04f'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('not foat/decimal notation', () => {
         const origArray = ['10.004Z', '10.039T', '10.038ooo', '10.037g'];
         const sortArray = ['10.004Z', '10.037g', '10.038ooo', '10.039T'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('scientific notation', () => {
@@ -744,21 +744,21 @@ describe('baseOrderBy()', () => {
           '1.52e15',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('negative numbers as strings', () => {
         const origArray = ['-1', '-2', '4', '-3', '0', '-5'];
         const sortArray = ['-5', '-3', '-2', '-1', '0', '4'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('numerics with prepended zero', () => {
         const origArray = ['1', '02', '3'];
         const sortArray = ['1', '02', '3'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('numerics with prepended zero and optional trailing characters', () => {
@@ -785,28 +785,28 @@ describe('baseOrderBy()', () => {
           '13',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('negative numbers as strings - mixed input type, string + numeric', () => {
         const origArray = [-1, '-2', 4, -3, '0', '-5'];
         const sortArray = ['-5', -3, '-2', -1, '0', 4];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('negative floats - all numeric', () => {
         const origArray = [-2.01, -2.1, 4.144, 4.1, -2.001, -5];
         const sortArray = [-5, -2.1, -2.01, -2.001, 4.1, 4.144];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('numerics with custom compare function', () => {
         const origArray = [-2.01, -2.1, 4.144, 4.1, -2.001, -5];
         const sortArray = [-5, -2.1, -2.01, -2.001, 4.1, 4.144];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -851,7 +851,7 @@ describe('baseOrderBy()', () => {
         '192.168.1.1',
       ];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+        expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
       });
     });
 
@@ -860,7 +860,7 @@ describe('baseOrderBy()', () => {
         const origArray = ['img12.png', 'img10.png', 'img2.png', 'img1.png'];
         const sortArray = ['img1.png', 'img2.png', 'img10.png', 'img12.png'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('complex filenames', () => {
@@ -885,7 +885,7 @@ describe('baseOrderBy()', () => {
           'asset_47103.jpg',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('complex filenames ordered by extension and name', () => {
@@ -926,7 +926,7 @@ describe('baseOrderBy()', () => {
           './system/kernel/js/02_my.desktop.js',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -935,7 +935,7 @@ describe('baseOrderBy()', () => {
       const origArray = ['alpha', ' 1', '  3', ' 2', 0];
       const sortArray = [0, ' 1', ' 2', '  3', 'alpha'];
       it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-        expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+        expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
       });
     });
 
@@ -944,14 +944,14 @@ describe('baseOrderBy()', () => {
         const origArray = ['10023', '999', '', 2, 5.663, 5.6629];
         const sortArray = ['', 2, 5.6629, 5.663, '999', '10023'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('zero as digits and strings and empty strings', () => {
         const origArray = [1, 0, '0', ''];
         const sortArray = ['', 0, '0', 1];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -961,14 +961,14 @@ describe('baseOrderBy()', () => {
         const origArray = ['0xA', '0x9', '0x99'];
         const sortArray = ['0x9', '0xA', '0x99'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('fake hex numbers', () => {
         const origArray = ['0xZZ', '0xVVV', '0xVEV', '0xUU'];
         const sortArray = ['0xUU', '0xVEV', '0xVVV', '0xZZ'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -978,7 +978,7 @@ describe('baseOrderBy()', () => {
         const origArray = ['\u0044', '\u0055', '\u0054', '\u0043'];
         const sortArray = ['\u0043', '\u0044', '\u0054', '\u0055'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('latin-1 supplement, default locale', () => {
@@ -1003,7 +1003,7 @@ describe('baseOrderBy()', () => {
           '\u007a',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('Sorting umlauts characters \xC4, \xD6, \xDC', () => {
@@ -1026,21 +1026,21 @@ describe('baseOrderBy()', () => {
           '\xDCxk\xFCll',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('localeCompare and equal chunks', () => {
         const origArray = ['drüben', 'hüben', 'wie', 'drüben', 'hüben'];
         const sortArray = ['drüben', 'drüben', 'hüben', 'hüben', 'wie'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('diacritics', () => {
         const origArray = ['b', 'd', 'f', 'A', 'Cé', 'E'];
         const sortArray = ['A', 'b', 'Cé', 'd', 'E', 'f'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('considers locale option', () => {
@@ -1083,14 +1083,14 @@ describe('baseOrderBy()', () => {
           undefined,
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('alphanumeric sparse array', () => {
         const origArray = [2, 10, 1, 'azd', undefined, 'asd'];
         const sortArray = [1, 2, 10, 'asd', 'azd', undefined];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -1100,14 +1100,14 @@ describe('baseOrderBy()', () => {
         const origArray = ['A', 'b', 'C', 'd', 'E', 'f'];
         const sortArray = ['A', 'b', 'C', 'd', 'E', 'f'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('case insensitive un-sorted array', () => {
         const origArray = ['A', 'C', 'E', 'b', 'd', 'f'];
         const sortArray = ['A', 'b', 'C', 'd', 'E', 'f'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -1127,7 +1127,7 @@ describe('baseOrderBy()', () => {
           'ignore leading spaces: 2-2',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('Ignoring multiple adjacent spaces (m.a.s)', () => {
@@ -1144,7 +1144,7 @@ describe('baseOrderBy()', () => {
           'ignore m.a.s spaces: 2-2',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('Equivalent whitespace characters', () => {
@@ -1165,7 +1165,7 @@ describe('baseOrderBy()', () => {
           'Equiv. spaces: 3-3',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('Case Indepenent sort', () => {
@@ -1182,7 +1182,7 @@ describe('baseOrderBy()', () => {
           'cASE INDEPENENT: 3-2',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('Numeric fields as numerics', () => {
@@ -1199,7 +1199,7 @@ describe('baseOrderBy()', () => {
           'foo1000bar99baz10.txt',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('Title sorts', () => {
@@ -1216,7 +1216,7 @@ describe('baseOrderBy()', () => {
           'Wanda',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
       describe('Equivalent accented characters (and case) case insensitive)', () => {
@@ -1233,7 +1233,7 @@ describe('baseOrderBy()', () => {
           'Equiv. \xfd accents: 2-2',
         ];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [], [], 'en')).toEqual(sortArray);
+          expect(baseOrderBy(origArray, [], [])).toEqual(sortArray);
         });
       });
     });
@@ -1243,7 +1243,7 @@ describe('baseOrderBy()', () => {
         const origArray = ['f', 'e', 'd', 'c', 'b', 'a'];
         const sortArray = ['f', 'e', 'd', 'c', 'b', 'a'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [(v) => v], ['desc'], 'en')).toEqual(
+          expect(baseOrderBy(origArray, [(v) => v], ['desc'])).toEqual(
             sortArray,
           );
         });
@@ -1252,7 +1252,7 @@ describe('baseOrderBy()', () => {
         const origArray = ['a', 'c', 'e', 'b', 'd', 'f'];
         const sortArray = ['f', 'e', 'd', 'c', 'b', 'a'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [(v) => v], ['desc'], 'en')).toEqual(
+          expect(baseOrderBy(origArray, [(v) => v], ['desc'])).toEqual(
             sortArray,
           );
         });
@@ -1261,7 +1261,7 @@ describe('baseOrderBy()', () => {
         const origArray = ['a', 'c', 'e', 'b', 'd', 'f'];
         const sortArray = ['a', 'b', 'c', 'd', 'e', 'f'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [(v) => v], ['asc'], 'en')).toEqual(
+          expect(baseOrderBy(origArray, [(v) => v], ['asc'])).toEqual(
             sortArray,
           );
         });
@@ -1270,7 +1270,7 @@ describe('baseOrderBy()', () => {
         const origArray = ['a', 'c', 'f', 'd', 'e', 'b'];
         const sortArray = ['a', 'b', 'c', 'd', 'e', 'f'];
         it(`${origArray.toString()} should be returned as ${sortArray.toString()}`, () => {
-          expect(baseOrderBy(origArray, [(v) => v], ['asc'], 'en')).toEqual(
+          expect(baseOrderBy(origArray, [(v) => v], ['asc'])).toEqual(
             sortArray,
           );
         });
@@ -1292,7 +1292,7 @@ describe('baseOrderBy()', () => {
         { user: 'fred', age: 40 },
         { user: 'Fred', age: 48 },
       ];
-      expect(baseOrderBy(origArray, [(value) => value.user], [], 'en')).toEqual(
+      expect(baseOrderBy(origArray, [(value) => value.user], [])).toEqual(
         sortArray,
       );
     });
@@ -1309,9 +1309,9 @@ describe('baseOrderBy()', () => {
         { user: 'fred', age: 40 },
         { user: 'Fred', age: 48 },
       ];
-      expect(
-        baseOrderBy(origArray, [(v) => v.user, (v) => v.age], [], 'en'),
-      ).toEqual(sortArray);
+      expect(baseOrderBy(origArray, [(v) => v.user, (v) => v.age], [])).toEqual(
+        sortArray,
+      );
     });
     it('should order by user ascending (default) and age ascending (default)', () => {
       const origArray = [
@@ -1326,9 +1326,7 @@ describe('baseOrderBy()', () => {
         { user: 'fred', age: 40 },
         { user: 'fred', age: 48 },
       ];
-      expect(baseOrderBy(origArray, ['user', 'age'], [], 'en')).toEqual(
-        sortArray,
-      );
+      expect(baseOrderBy(origArray, ['user', 'age'], [])).toEqual(sortArray);
     });
     it('should order by user ascending (default) and age ascending', () => {
       const origArray = [
@@ -1343,7 +1341,7 @@ describe('baseOrderBy()', () => {
         { user: 'fred', age: 40 },
         { user: 'fred', age: 48 },
       ];
-      expect(baseOrderBy(origArray, ['user', 'age'], ['asc'], 'en')).toEqual(
+      expect(baseOrderBy(origArray, ['user', 'age'], ['asc'])).toEqual(
         sortArray,
       );
     });
@@ -1360,9 +1358,9 @@ describe('baseOrderBy()', () => {
         { user: 'fred', age: 48 },
         { user: 'fred', age: 40 },
       ];
-      expect(
-        baseOrderBy(origArray, ['user', 'age'], ['asc', 'desc'], 'en'),
-      ).toEqual(sortArray);
+      expect(baseOrderBy(origArray, ['user', 'age'], ['asc', 'desc'])).toEqual(
+        sortArray,
+      );
     });
     it('should order by user ascending and age ascending (default)', () => {
       const origArray = [
@@ -1377,9 +1375,9 @@ describe('baseOrderBy()', () => {
         { user: 'fred', age: 40 },
         { user: 'fred', age: 48 },
       ];
-      expect(
-        baseOrderBy(origArray, [(v) => v.user, (v) => v.age], [], 'en'),
-      ).toEqual(sortArray);
+      expect(baseOrderBy(origArray, [(v) => v.user, (v) => v.age], [])).toEqual(
+        sortArray,
+      );
     });
     it('should order by user descending (default) and age ascending (default) case insensitive', () => {
       const origArray = [
@@ -1416,9 +1414,9 @@ describe('baseOrderBy()', () => {
         { user: 'barney', age: 34 },
         { user: 'barney', age: 36 },
       ];
-      expect(
-        baseOrderBy(origArray, ['user', 'age'], ['desc', 'asc'], 'en'),
-      ).toEqual(sortArray);
+      expect(baseOrderBy(origArray, ['user', 'age'], ['desc', 'asc'])).toEqual(
+        sortArray,
+      );
     });
     it('should order by user ascending and age ascending', () => {
       const origArray = [
@@ -1433,9 +1431,9 @@ describe('baseOrderBy()', () => {
         { user: 'fred', age: 40 },
         { user: 'fred', age: 48 },
       ];
-      expect(
-        baseOrderBy(origArray, ['user', 'age'], ['asc', 'asc'], 'en'),
-      ).toEqual(sortArray);
+      expect(baseOrderBy(origArray, ['user', 'age'], ['asc', 'asc'])).toEqual(
+        sortArray,
+      );
     });
     it('should order by user ascending and age descending', () => {
       const origArray = [
@@ -1452,9 +1450,9 @@ describe('baseOrderBy()', () => {
         { user: 'fred', age: 40 },
         { user: 'wilma', age: 32 },
       ];
-      expect(
-        baseOrderBy(origArray, ['user', 'age'], ['asc', 'desc'], 'en'),
-      ).toEqual(sortArray);
+      expect(baseOrderBy(origArray, ['user', 'age'], ['asc', 'desc'])).toEqual(
+        sortArray,
+      );
     });
     it('should order by user descending and age ascending', () => {
       const origArray = [
@@ -1469,9 +1467,9 @@ describe('baseOrderBy()', () => {
         { user: 'barney', age: 34 },
         { user: 'barney', age: 36 },
       ];
-      expect(
-        baseOrderBy(origArray, ['user', 'age'], ['desc', 'asc'], 'en'),
-      ).toEqual(sortArray);
+      expect(baseOrderBy(origArray, ['user', 'age'], ['desc', 'asc'])).toEqual(
+        sortArray,
+      );
     });
     it('should order by user ascending (default) and age ascending (default) using functional identifiers', () => {
       const origArray = [
@@ -1486,9 +1484,9 @@ describe('baseOrderBy()', () => {
         { user: 'fred', age: 40 },
         { user: 'fred', age: 48 },
       ];
-      expect(
-        baseOrderBy(origArray, [(v) => v.user, (v) => v.age], [], 'en'),
-      ).toEqual(sortArray);
+      expect(baseOrderBy(origArray, [(v) => v.user, (v) => v.age], [])).toEqual(
+        sortArray,
+      );
     });
     it('should order by datetime descending and ip ascending using functional identifiers', () => {
       const origArray = [
@@ -1600,7 +1598,7 @@ describe('baseOrderBy()', () => {
         ['fred', 40],
         ['Fred', 48],
       ];
-      expect(baseOrderBy(origArray, [0, 1], [], 'en')).toEqual(sortArray);
+      expect(baseOrderBy(origArray, [0, 1], [])).toEqual(sortArray);
     });
     it('should order by first element ascending (default) and second element ascending (default)', () => {
       const origArray = [
@@ -1615,7 +1613,7 @@ describe('baseOrderBy()', () => {
         ['fred', 40],
         ['fred', 48],
       ];
-      expect(baseOrderBy(origArray, [0, 1], [], 'en')).toEqual(sortArray);
+      expect(baseOrderBy(origArray, [0, 1], [])).toEqual(sortArray);
     });
     it('should order by first element ascending (default) and second element ascending', () => {
       const origArray = [
@@ -1630,9 +1628,7 @@ describe('baseOrderBy()', () => {
         ['fred', 40],
         ['fred', 48],
       ];
-      expect(baseOrderBy(origArray, [0, 1], ['asc', 'asc'], 'en')).toEqual(
-        sortArray,
-      );
+      expect(baseOrderBy(origArray, [0, 1], ['asc', 'asc'])).toEqual(sortArray);
     });
     it('should order by first element ascending (default) and second element descending', () => {
       const origArray = [
@@ -1647,7 +1643,7 @@ describe('baseOrderBy()', () => {
         ['fred', 48],
         ['fred', 40],
       ];
-      expect(baseOrderBy(origArray, [0, 1], ['asc', 'desc'], 'en')).toEqual(
+      expect(baseOrderBy(origArray, [0, 1], ['asc', 'desc'])).toEqual(
         sortArray,
       );
     });
@@ -1665,7 +1661,7 @@ describe('baseOrderBy()', () => {
         ['fred', 48],
       ];
       expect(
-        baseOrderBy(origArray, [(v) => v[0], (v) => v[1]], ['asc'], 'en'),
+        baseOrderBy(origArray, [(v) => v[0], (v) => v[1]], ['asc']),
       ).toEqual(sortArray);
     });
     it('should order by first element descending and second element ascending (default)', () => {
@@ -1681,7 +1677,7 @@ describe('baseOrderBy()', () => {
         ['barney', 34],
         ['barney', 36],
       ];
-      expect(baseOrderBy(origArray, [0, 1], ['desc'], 'en')).toEqual(sortArray);
+      expect(baseOrderBy(origArray, [0, 1], ['desc'])).toEqual(sortArray);
     });
     it('should order by first element ascending and second element ascending', () => {
       const origArray = [
@@ -1696,9 +1692,7 @@ describe('baseOrderBy()', () => {
         ['fred', 40],
         ['fred', 48],
       ];
-      expect(baseOrderBy(origArray, [0, 1], ['asc', 'asc'], 'en')).toEqual(
-        sortArray,
-      );
+      expect(baseOrderBy(origArray, [0, 1], ['asc', 'asc'])).toEqual(sortArray);
     });
     it('should order by first element ascending and second element descending', () => {
       const origArray = [
@@ -1715,7 +1709,7 @@ describe('baseOrderBy()', () => {
         ['fred', 40],
         ['wilma', 32],
       ];
-      expect(baseOrderBy(origArray, [0, 1], ['asc', 'desc'], 'en')).toEqual(
+      expect(baseOrderBy(origArray, [0, 1], ['asc', 'desc'])).toEqual(
         sortArray,
       );
     });
@@ -1732,7 +1726,7 @@ describe('baseOrderBy()', () => {
         ['barney', 34],
         ['barney', 36],
       ];
-      expect(baseOrderBy(origArray, [0, 1], ['desc', 'asc'], 'en')).toEqual(
+      expect(baseOrderBy(origArray, [0, 1], ['desc', 'asc'])).toEqual(
         sortArray,
       );
     });
@@ -1749,9 +1743,9 @@ describe('baseOrderBy()', () => {
         ['fred', 40],
         ['fred', 48],
       ];
-      expect(
-        baseOrderBy(origArray, [(v) => v[0], (v) => v[1]], [], 'en'),
-      ).toEqual(sortArray);
+      expect(baseOrderBy(origArray, [(v) => v[0], (v) => v[1]], [])).toEqual(
+        sortArray,
+      );
     });
   });
 });

--- a/src/utils/__tests__/compareChunks.test.ts
+++ b/src/utils/__tests__/compareChunks.test.ts
@@ -16,7 +16,7 @@ describe('compareChunks()', () => {
       { parsedNumber: undefined, normalizedString: '.' },
       { parsedNumber: 1, normalizedString: '1' },
     ];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeLessThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeLessThan(0);
   });
   it('should return 0 when comparing chunks (2)', () => {
     const chunksA = [
@@ -33,7 +33,7 @@ describe('compareChunks()', () => {
       { parsedNumber: undefined, normalizedString: '.' },
       { parsedNumber: 0, normalizedString: '0' },
     ];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBe(0);
+    expect(compareChunks(chunksA, chunksB)).toBe(0);
   });
   it('should return 1 when comparing chunks (3)', () => {
     const chunksA = [
@@ -50,7 +50,7 @@ describe('compareChunks()', () => {
       { parsedNumber: undefined, normalizedString: '.' },
       { parsedNumber: 0, normalizedString: '0' },
     ];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeGreaterThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeGreaterThan(0);
   });
   it('should return -1 when comparing chunks (4)', () => {
     const chunksA = [
@@ -67,7 +67,7 @@ describe('compareChunks()', () => {
       { parsedNumber: undefined, normalizedString: '.' },
       { parsedNumber: 0, normalizedString: '0' },
     ];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeLessThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeLessThan(0);
   });
   it('should return -1 when comparing chunks (5)', () => {
     const chunksA = [
@@ -85,76 +85,76 @@ describe('compareChunks()', () => {
       { parsedNumber: undefined, normalizedString: '.' },
       { parsedNumber: 0, normalizedString: '0' },
     ];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeGreaterThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeGreaterThan(0);
   });
   it('should return -1 when comparing chunks (6)', () => {
     const chunksA = [{ parsedNumber: 1, normalizedString: '1' }];
     const chunksB = [{ parsedNumber: undefined, normalizedString: 'x' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeLessThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeLessThan(0);
   });
   it('should return 1 when comparing chunks (7)', () => {
     const chunksA = [{ parsedNumber: undefined, normalizedString: 'x' }];
     const chunksB = [{ parsedNumber: 1, normalizedString: '1' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeGreaterThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeGreaterThan(0);
   });
   it('should return -1 when comparing chunks (8)', () => {
     const chunksA = [{ parsedNumber: undefined, normalizedString: 'ö' }];
     const chunksB = [{ parsedNumber: undefined, normalizedString: 'ü' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeLessThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeLessThan(0);
   });
   it('should return 0 when comparing chunks (9)', () => {
     const chunksA = [{ parsedNumber: undefined, normalizedString: 'ö' }];
     const chunksB = [{ parsedNumber: undefined, normalizedString: 'ö' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBe(0);
+    expect(compareChunks(chunksA, chunksB)).toBe(0);
   });
   it('should return 1 when comparing chunks (10)', () => {
     const chunksA = [{ parsedNumber: undefined, normalizedString: 'ü' }];
     const chunksB = [{ parsedNumber: undefined, normalizedString: 'ö' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeGreaterThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeGreaterThan(0);
   });
   it('should return -1 when comparing chunks (11)', () => {
     const chunksA = [{ parsedNumber: undefined, normalizedString: 'a' }];
     const chunksB = [{ parsedNumber: undefined, normalizedString: 'b' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeLessThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeLessThan(0);
   });
   it('should return 0 when comparing chunks (12)', () => {
     const chunksA = [{ parsedNumber: undefined, normalizedString: 'a' }];
     const chunksB = [{ parsedNumber: undefined, normalizedString: 'a' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBe(0);
+    expect(compareChunks(chunksA, chunksB)).toBe(0);
   });
   it('should return 1 when comparing chunks (13)', () => {
     const chunksA = [{ parsedNumber: undefined, normalizedString: 'b' }];
     const chunksB = [{ parsedNumber: undefined, normalizedString: 'a' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeGreaterThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeGreaterThan(0);
   });
   it('should return -1 when comparing chunks (14)', () => {
     const chunksA = [{ parsedNumber: undefined, normalizedString: '' }];
     const chunksB = [{ parsedNumber: 0, normalizedString: '0' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeLessThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeLessThan(0);
   });
   it('should return 0 when comparing chunks (15)', () => {
     const chunksA = [{ parsedNumber: undefined, normalizedString: '' }];
     const chunksB = [{ parsedNumber: undefined, normalizedString: '' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBe(0);
+    expect(compareChunks(chunksA, chunksB)).toBe(0);
   });
   it('should return 1 when comparing chunks (16)', () => {
     const chunksA = [{ parsedNumber: 0, normalizedString: '0' }];
     const chunksB = [{ parsedNumber: undefined, normalizedString: '' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeGreaterThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeGreaterThan(0);
   });
   it('should return -1 when comparing chunks (17)', () => {
     const chunksA = [{ parsedNumber: 1, normalizedString: '001' }];
     const chunksB = [{ parsedNumber: 1, normalizedString: '01' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeLessThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeLessThan(0);
   });
   it('should return -1 when comparing chunks (18)', () => {
     const chunksA = [{ parsedNumber: 1, normalizedString: '001' }];
     const chunksB = [{ parsedNumber: 1, normalizedString: '001' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBe(0);
+    expect(compareChunks(chunksA, chunksB)).toBe(0);
   });
   it('should return 1 when comparing chunks (19)', () => {
     const chunksA = [{ parsedNumber: 1, normalizedString: '01' }];
     const chunksB = [{ parsedNumber: 1, normalizedString: '001' }];
-    expect(compareChunks(chunksA, chunksB, 'en')).toBeGreaterThan(0);
+    expect(compareChunks(chunksA, chunksB)).toBeGreaterThan(0);
   });
 });

--- a/src/utils/__tests__/compareMultiple.test.ts
+++ b/src/utils/__tests__/compareMultiple.test.ts
@@ -23,7 +23,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(compareMultiple(recordA, recordB, [], 'en')).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, [])).toBeLessThan(0);
     });
     it('should call compareValues() and return result without changing order (2)', () => {
       const recordA = {
@@ -46,7 +46,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(compareMultiple(recordA, recordB, [], 'en')).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, [])).toBeLessThan(0);
     });
     it('should call compareValues() and return result without changing order (3)', () => {
       const recordA = {
@@ -69,7 +69,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(compareMultiple(recordA, recordB, [], 'en')).toBeGreaterThan(0);
+      expect(compareMultiple(recordA, recordB, [])).toBeGreaterThan(0);
     });
   });
   describe('ascending order', () => {
@@ -94,7 +94,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(compareMultiple(recordA, recordB, ['asc'], 'en')).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, ['asc'])).toBeLessThan(0);
     });
     it('should call compareValues() and return result without changing order (5)', () => {
       const recordA = {
@@ -117,7 +117,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(compareMultiple(recordA, recordB, ['asc'], 'en')).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, ['asc'])).toBeLessThan(0);
     });
     it('should call compareValues() and return result without changing order (6)', () => {
       const recordA = {
@@ -140,9 +140,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(compareMultiple(recordA, recordB, ['asc'], 'en')).toBeGreaterThan(
-        0,
-      );
+      expect(compareMultiple(recordA, recordB, ['asc'])).toBeGreaterThan(0);
     });
   });
   describe('descending order', () => {
@@ -167,9 +165,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(compareMultiple(recordA, recordB, ['desc'], 'en')).toBeGreaterThan(
-        0,
-      );
+      expect(compareMultiple(recordA, recordB, ['desc'])).toBeGreaterThan(0);
     });
     it('should call compareValues() and return result without changing (8)', () => {
       const recordA = {
@@ -192,7 +188,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(compareMultiple(recordA, recordB, ['desc'], 'en')).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, ['desc'])).toBeLessThan(0);
     });
     it('should call compareValues() and return result changed to descending order (9)', () => {
       const recordA = {
@@ -215,7 +211,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(compareMultiple(recordA, recordB, ['desc'], 'en')).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, ['desc'])).toBeLessThan(0);
     });
   });
   describe('mixed order', () => {
@@ -248,9 +244,9 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(
-        compareMultiple(recordA, recordB, ['desc', 'asc'], 'en'),
-      ).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, ['desc', 'asc'])).toBeLessThan(
+        0,
+      );
     });
     it('should call compareValues() twice and return result without changing order (11)', () => {
       const recordA = {
@@ -281,9 +277,9 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(
-        compareMultiple(recordA, recordB, ['desc', 'asc'], 'en'),
-      ).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, ['desc', 'asc'])).toBeLessThan(
+        0,
+      );
     });
     it('should call compareValues() twice and return result without changing order (12)', () => {
       const recordA = {
@@ -315,7 +311,7 @@ describe('compareMultiple()', () => {
         ],
       };
       expect(
-        compareMultiple(recordA, recordB, ['asc', 'desc'], 'en'),
+        compareMultiple(recordA, recordB, ['asc', 'desc']),
       ).toBeGreaterThan(0);
     });
   });
@@ -350,9 +346,9 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(
-        compareMultiple(recordA, recordB, ['desc', order], 'en'),
-      ).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, ['desc', order])).toBeLessThan(
+        0,
+      );
       expect(order).toHaveBeenCalledTimes(1);
       expect(order).toHaveBeenCalledWith(
         recordA.values[1].value,
@@ -389,9 +385,7 @@ describe('compareMultiple()', () => {
           },
         ],
       };
-      expect(
-        compareMultiple(recordA, recordB, [order, 'asc'], 'en'),
-      ).toBeLessThan(0);
+      expect(compareMultiple(recordA, recordB, [order, 'asc'])).toBeLessThan(0);
       expect(order).toHaveBeenCalledTimes(1);
       expect(order).toHaveBeenCalledWith(
         recordA.values[0].value,

--- a/src/utils/__tests__/compareUnicode.test.ts
+++ b/src/utils/__tests__/compareUnicode.test.ts
@@ -4,16 +4,16 @@ describe('compareUnicode()', () => {
   it('should return -1', () => {
     const valueX = 'ö';
     const valueY = 'ü';
-    expect(compareUnicode(valueX, valueY, 'en')).toBeLessThan(0);
+    expect(compareUnicode(valueX, valueY)).toBeLessThan(0);
   });
   it('should return 0', () => {
     const valueX = 'ö';
     const valueY = 'ö';
-    expect(compareUnicode(valueX, valueY, 'en')).toBe(0);
+    expect(compareUnicode(valueX, valueY)).toBe(0);
   });
   it('should return 1', () => {
     const valueX = 'ü';
     const valueY = 'ö';
-    expect(compareUnicode(valueX, valueY, 'en')).toBeGreaterThan(0);
+    expect(compareUnicode(valueX, valueY)).toBeGreaterThan(0);
   });
 });

--- a/src/utils/__tests__/compareValues.test.ts
+++ b/src/utils/__tests__/compareValues.test.ts
@@ -13,7 +13,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: 0, normalizedString: '0' }],
         value: 0,
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are equal strings', () => {
       const valueA = {
@@ -24,7 +24,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: undefined, normalizedString: 'a' }],
         value: 'a',
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are equal booleans (true)', () => {
       const valueA = {
@@ -37,7 +37,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: 1, normalizedString: '1' }],
         value: true,
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are equal booleans (false)', () => {
       const valueA = {
@@ -50,7 +50,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: 0, normalizedString: '0' }],
         value: false,
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are NaN', () => {
       const valueA = {
@@ -73,7 +73,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: NaN,
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are Symbol', () => {
       const valueA = {
@@ -96,7 +96,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: Symbol('foo'),
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are objects', () => {
       const valueA = {
@@ -119,7 +119,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: {},
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are arrays', () => {
       const valueA = {
@@ -142,7 +142,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: [1, 2],
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are functions', () => {
       const valueA = {
@@ -169,7 +169,7 @@ describe('compareValues()', () => {
           return 0;
         },
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are null', () => {
       const valueA = {
@@ -192,7 +192,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: null,
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
     it('should return 0, if both values are undefined', () => {
       const valueA = {
@@ -215,7 +215,7 @@ describe('compareValues()', () => {
         isUndefined: true,
         value: undefined,
       };
-      expect(compareValues(valueA, valueB, 'en')).toBe(0);
+      expect(compareValues(valueA, valueB)).toBe(0);
     });
   });
   describe('unequal values', () => {
@@ -230,7 +230,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: 1, normalizedString: '1' }],
         value: 1,
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareChunks, if both values are unequal strings', () => {
       const valueA = {
@@ -241,7 +241,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: undefined, normalizedString: 'b' }],
         value: 'b',
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareChunks, if first value is a number and second value is a string', () => {
       const valueA = {
@@ -252,7 +252,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: undefined, normalizedString: 'b' }],
         value: 'b',
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareChunks, if first value is a string and second value is a number', () => {
       const valueA = {
@@ -263,7 +263,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: 1, normalizedString: '1' }],
         value: 1,
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareOtherTypes, if first value is a number and second value is NaN', () => {
       const valueA = {
@@ -281,7 +281,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: NaN,
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareOtherTypes, if first value is NaN and second value is a number', () => {
       const valueA = {
@@ -299,7 +299,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: 1, normalizedString: '1' }],
         value: 1,
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareOtherTypes, if first value is a string and second value is NaN', () => {
       const valueA = {
@@ -316,7 +316,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: NaN,
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareOtherTypes, if first value is NaN and second value is a string', () => {
       const valueA = {
@@ -333,7 +333,7 @@ describe('compareValues()', () => {
         chunks: [{ parsedNumber: undefined, normalizedString: 'b' }],
         value: 'b',
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareOtherTypes, if first value is a Symbol and second value is an object', () => {
       const valueA = {
@@ -356,7 +356,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: {},
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareOtherTypes, if first value is an object and second value is an array', () => {
       const valueA = {
@@ -379,7 +379,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: [],
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareOtherTypes, if first value is an array and second value is a function', () => {
       const valueA = {
@@ -404,7 +404,7 @@ describe('compareValues()', () => {
           return;
         },
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareOtherTypes, if first value is a function and second value is null', () => {
       const valueA = {
@@ -429,7 +429,7 @@ describe('compareValues()', () => {
         isUndefined: false,
         value: null,
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
     it('should call compareOtherTypes, if first value is null and second value is undefined', () => {
       const valueA = {
@@ -452,7 +452,7 @@ describe('compareValues()', () => {
         isUndefined: true,
         value: undefined,
       };
-      expect(compareValues(valueA, valueB, 'en')).not.toBe(0);
+      expect(compareValues(valueA, valueB)).not.toBe(0);
     });
   });
 });

--- a/src/utils/__tests__/getOptions.test.ts
+++ b/src/utils/__tests__/getOptions.test.ts
@@ -3,7 +3,7 @@ import { getOptions } from '../getOptions';
 
 const defaultOptions: CompareOptions = {
   order: 'asc',
-  locale: 'en',
+  locale: undefined,
 };
 
 describe('getOptions()', () => {

--- a/src/utils/baseOrderBy.ts
+++ b/src/utils/baseOrderBy.ts
@@ -15,7 +15,7 @@ export const baseOrderBy = <T>(
   collection: ReadonlyArray<T>,
   identifiers: ReadonlyArray<Identifier<T>>,
   orders: ReadonlyArray<Order>,
-  locale: Locale,
+  locale?: Locale,
 ): Array<T> => {
   const identifierFns: Array<IdentifierFn<T>> = identifiers.length
     ? identifiers.map(createIdentifierFn)

--- a/src/utils/compareChunks.ts
+++ b/src/utils/compareChunks.ts
@@ -7,7 +7,7 @@ import type { ChunkMaps, Locale } from '../types';
 export const compareChunks = (
   chunksA: ChunkMaps,
   chunksB: ChunkMaps,
-  locale: Locale,
+  locale?: Locale,
 ): number => {
   const lengthA = chunksA.length;
   const lengthB = chunksB.length;

--- a/src/utils/compareMultiple.ts
+++ b/src/utils/compareMultiple.ts
@@ -5,7 +5,7 @@ export const compareMultiple = (
   recordA: MappedRecord,
   recordB: MappedRecord,
   orders: ReadonlyArray<Order>,
-  locale: Locale,
+  locale?: Locale,
 ): number => {
   const { index: indexA, values: valuesA } = recordA;
   const { index: indexB, values: valuesB } = recordB;

--- a/src/utils/compareUnicode.ts
+++ b/src/utils/compareUnicode.ts
@@ -3,7 +3,7 @@ import type { Locale } from '../types';
 export const compareUnicode = (
   stringA: string,
   stringB: string,
-  locale: Locale,
+  locale?: Locale,
 ): number => {
   const result = stringA.localeCompare(stringB, locale);
   return result ? result / Math.abs(result) : 0;

--- a/src/utils/compareValues.ts
+++ b/src/utils/compareValues.ts
@@ -6,7 +6,7 @@ import type { MappedValueRecord, Locale } from '../types';
 export const compareValues = (
   valueA: MappedValueRecord,
   valueB: MappedValueRecord,
-  locale: Locale,
+  locale?: Locale,
 ): number => {
   if (valueA.value === valueB.value) {
     return 0;

--- a/src/utils/getOptions.ts
+++ b/src/utils/getOptions.ts
@@ -7,7 +7,7 @@ export const getOptions = (
   customOptions?: CompareOptions,
 ): BaseCompareOptions => {
   let order: OrderEnum = 'asc';
-  let locale = 'en';
+  let locale; // = 'en';
   if (typeof customOptions === 'string' && isValidOrder(customOptions)) {
     order = customOptions;
   } else if (customOptions && typeof customOptions === 'object') {


### PR DESCRIPTION
If no explicit locale has been provided to `compare()` or `orderBy()` there should be the locale setting of the host be acknowledged.